### PR TITLE
OPS-57: Add PayoutStatusType for PayoutSearchQuery

### DIFF
--- a/proto/magista.thrift
+++ b/proto/magista.thrift
@@ -49,7 +49,7 @@ struct ChargebackSearchQuery {
 struct PayoutSearchQuery {
     1: required CommonSearchQueryParams common_search_query_params
     2: optional payout_manager.PayoutID payout_id
-    3: optional list<payout_manager.PayoutStatus> payout_statuses
+    3: optional list<PayoutStatusType> payout_status_types
     4: optional PayoutToolType payout_type
 }
 
@@ -57,6 +57,13 @@ enum PayoutToolType {
     payout_account
     wallet
     payment_institution_account
+}
+
+enum PayoutStatusType {
+    unpaid
+    paid
+    cancelled
+    confirmed
 }
 
 struct InvoiceTemplateSearchQuery {


### PR DESCRIPTION
Сейчас у объектов в `union payout_manager.PayoutStatus` есть обязательные поля, которые не позволяют искать, заменил enum'ом.