### PR TITLE
TD-266: Drop valitydev/payout-manager-proto dep altogether

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,12 +63,6 @@
             <version>1.551-df1c52f</version>
             <scope>provided</scope>
         </dependency>
-        <dependency>
-            <groupId>dev.vality</groupId>
-            <artifactId>payout-manager-proto</artifactId>
-            <version>1.27-1fac5a3</version>
-            <scope>provided</scope>
-        </dependency>
     </dependencies>
 
     <build>

--- a/proto/magista.thrift
+++ b/proto/magista.thrift
@@ -1,10 +1,10 @@
 include "proto/base.thrift"
 include "proto/domain.thrift"
-include "proto/payout_manager.thrift"
 
 namespace java dev.vality.magista
 namespace erlang magista
 
+typedef base.ID PayoutID
 typedef string ContinuationToken
 
 exception BadContinuationToken { 1: string reason }
@@ -48,7 +48,7 @@ struct ChargebackSearchQuery {
 
 struct PayoutSearchQuery {
     1: required CommonSearchQueryParams common_search_query_params
-    2: optional payout_manager.PayoutID payout_id
+    2: optional PayoutID payout_id
     3: optional list<PayoutStatusType> payout_status_types
     4: optional PayoutToolType payout_type
 }

--- a/proto/magista.thrift
+++ b/proto/magista.thrift
@@ -4,7 +4,9 @@ include "proto/domain.thrift"
 namespace java dev.vality.magista
 namespace erlang magista
 
+// See https://github.com/valitydev/payout-manager-proto/blob/063163dc/proto/payout_manager.thrift#L7
 typedef base.ID PayoutID
+
 typedef string ContinuationToken
 
 exception BadContinuationToken { 1: string reason }
@@ -249,8 +251,6 @@ struct StatCustomer {
     1: required domain.Fingerprint id
     2: required base.Timestamp created_at
 }
-
-typedef base.ID PayoutID
 
 struct StatPayout {
     1: required PayoutID id

--- a/rebar.config
+++ b/rebar.config
@@ -29,10 +29,6 @@
     {damsel,
         {git, "https://github.com/valitydev/damsel.git",
         {branch, "master"}}
-    },
-    {payout_manager_proto,
-        {git, "https://github.com/valitydev/payout-manager-proto.git",
-        {branch, "master"}}
     }
 ]}.
 
@@ -67,7 +63,7 @@
 {provider_hooks, [
     {pre, [
         {compile, {thrift, compile}},
-        {clean  , {thrift, clean  }}
+        {clean, {thrift, clean}}
     ]}
 ]}.
 

--- a/rebar.lock
+++ b/rebar.lock
@@ -2,7 +2,7 @@
   {git,"https://github.com/valitydev/damsel.git",
        {ref,"df1c52f2ebe175fabe1da4aec8ac889b2dd03a0b"}},
   0},
-  {<<"payout_manager_proto">>,
-    {git,"https://github.com/valitydev/payout-manager-proto.git",
-         {ref,"1fac5a36c6b315625e77509371a44ebe543c96df"}},
-    0}].
+ {<<"payout_manager_proto">>,
+  {git,"https://github.com/valitydev/payout-manager-proto.git",
+       {ref,"1fac5a36c6b315625e77509371a44ebe543c96df"}},
+  0}].


### PR DESCRIPTION
Unqualified include `proto/domain.thrift` is ambiguous. There's `domain.thrift` both in damsel and payout-manager-proto. Ideally we need qualified include (e.g. `include "payout-manager-proto/proto/domain.thrift"`) but in the meantime dropping dependency will suffice, there was just a single typedef reference anyway.